### PR TITLE
Break up into two classes - a base class (which directly maps to the …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular4-swagger-client-generator",
-  "version": "0.1.4",
+  "version": "0.1.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/templates/angular2-model-base.mustache
+++ b/templates/angular2-model-base.mustache
@@ -1,0 +1,22 @@
+{{#imports}}
+import { {{.}} } from './{{#lower}}{{.}}{{/lower}}.model'
+{{/imports}}
+
+export interface _{{&name}} {
+{{#properties}}
+  {{#isArray}}
+  {{name}}: {{typescriptType}}[];
+  {{/isArray}}
+  {{^isArray}}
+  {{name}}: {{typescriptType}};
+  {{/isArray}}
+{{/properties}}
+{{#refs}}
+  {{#isArray}}
+  {{name}}: {{typescriptType}}[];
+  {{/isArray}}
+  {{^isArray}}
+  {{name}}: {{typescriptType}};
+  {{/isArray}}
+{{/refs}}
+}

--- a/templates/angular2-model.mustache
+++ b/templates/angular2-model.mustache
@@ -1,22 +1,4 @@
-{{#imports}}
-import { {{.}} } from './{{#lower}}{{.}}{{/lower}}.model'
-{{/imports}}
+import { _{{&name}} } from './_{{#lower}}{{&name}}{{/lower}}.model'
 
-export interface {{&name}} {
-{{#properties}}
-  {{#isArray}}
-  {{name}}: {{typescriptType}}[];
-  {{/isArray}}
-  {{^isArray}}
-  {{name}}: {{typescriptType}};
-  {{/isArray}}
-{{/properties}}
-{{#refs}}
-  {{#isArray}}
-  {{name}}: {{typescriptType}}[];
-  {{/isArray}}
-  {{^isArray}}
-  {{name}}: {{typescriptType}};
-  {{/isArray}}
-{{/refs}}
+export interface {{&name}} extends _{{&name}} {
 }


### PR DESCRIPTION
…swagger spec and is overwritten every time) and a wrapper class, which is not overwritten if it already exists. This allows developers to annotate the wrapper class with transient variables while retaining type safety